### PR TITLE
fix(floimg-google): prevent AI workflow generator model hallucination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,31 @@ All notable changes to FloImg will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.22.0] - 2026-02-03
 
-### @teamflojo/floimg-studio-ui
+Iterative AI Workflow Editing - Users can now refine workflows through conversation with canvas-aware AI.
 
-- feat: AI can make targeted changes to existing workflows (add/modify/delete nodes)
-- feat: Operations mode allows iterative workflow refinement without full replacement
+### @teamflojo/floimg-studio-ui (0.11.0)
+
+- feat: AI iterative operations - add/modify/delete nodes and connections
+- feat: Conflict detection when user edits conflict with AI changes
+- feat: ConflictResolutionModal for resolving merge conflicts
+- feat: Quick actions based on canvas state (add save node, post-processing, etc.)
+- feat: "Apply as New" button for workflow forking
 - feat: Show change summary when AI operations are applied
 
-### @teamflojo/floimg-studio-shared
+### @teamflojo/floimg-studio-shared (0.10.0)
 
 - feat: Add AIWorkflowOperation types for iterative AI editing
 - feat: Add CanvasSnapshot interface for canvas state context
 - feat: Add GenerationSSEIterative event type
+- feat: Add conflict detection types (ConflictType, OperationConflict, ResolvedConflict)
 
-### @teamflojo/floimg-studio-backend
+### @teamflojo/floimg-studio-backend (0.6.0)
 
 - feat: Add generateIterativeWorkflow() for canvas-aware AI generation
 - feat: Operations-based responses instead of full workflow replacement
+- feat: AI chooses mode (replace vs operations) based on canvas state
 
 ## [v0.21.20] - 2026-02-03
 

--- a/apps/studio/backend/package.json
+++ b/apps/studio/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamflojo/floimg-studio-backend",
-  "version": "0.5.8",
+  "version": "0.6.0",
   "description": "FloImg Studio backend server with API and workflow execution",
   "type": "module",
   "license": "MIT",

--- a/apps/studio/frontend/package.json
+++ b/apps/studio/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamflojo/floimg-studio-ui",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "FloImg Studio React components for building visual workflow editors",
   "type": "module",
   "license": "MIT",

--- a/apps/studio/shared/package.json
+++ b/apps/studio/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamflojo/floimg-studio-shared",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Shared types and utilities for FloImg Studio",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floimg-monorepo",
-  "version": "0.21.20",
+  "version": "0.22.0",
   "private": true,
   "description": "floimg monorepo - universal image workflow engine for developers and AI agents",
   "scripts": {

--- a/packages/floimg-google/src/index.ts
+++ b/packages/floimg-google/src/index.ts
@@ -61,6 +61,9 @@ export const googleImagenSchema: GeneratorSchema = {
   isAI: true,
   requiresApiKey: true,
   apiKeyEnvVar: "GOOGLE_AI_API_KEY",
+  // Imagen API is text-to-image only - does NOT support reference images
+  // Use gemini-generate instead for image-to-image generation with references
+  acceptsReferenceImages: false,
 };
 
 /**

--- a/packages/floimg-google/src/transforms.ts
+++ b/packages/floimg-google/src/transforms.ts
@@ -27,10 +27,10 @@ interface GeminiImageGenerationConfig extends GenerateContentConfig {
 }
 
 /**
- * Supported Gemini models for image generation/editing (Nano Banana)
+ * Supported Gemini models for image generation/editing
  *
- * - gemini-2.5-flash-image: "Nano Banana" - Fast, high-volume, low-latency
- * - gemini-3-pro-image-preview: "Nano Banana Pro" - Professional quality, better text rendering
+ * - gemini-2.5-flash-image: Fast, high-volume, low-latency
+ * - gemini-3-pro-image-preview: Professional quality, better text rendering
  */
 const GEMINI_IMAGE_MODELS = ["gemini-2.5-flash-image", "gemini-3-pro-image-preview"] as const;
 
@@ -109,7 +109,8 @@ export const geminiEditSchema: TransformOperationSchema = {
     model: {
       type: "string",
       title: "Model",
-      description: "Gemini model to use: Nano Banana (fast) or Nano Banana Pro (high quality)",
+      description:
+        "Gemini model: gemini-2.5-flash-image (fast) or gemini-3-pro-image-preview (high quality)",
       enum: [...GEMINI_IMAGE_MODELS],
       default: "gemini-2.5-flash-image",
     },
@@ -467,7 +468,8 @@ export const geminiGenerateSchema: GeneratorSchema = {
     model: {
       type: "string",
       title: "Model",
-      description: "Gemini model to use: Nano Banana (fast) or Nano Banana Pro (high quality)",
+      description:
+        "Gemini model: gemini-2.5-flash-image (fast) or gemini-3-pro-image-preview (high quality)",
       enum: [...GEMINI_IMAGE_MODELS],
       default: "gemini-2.5-flash-image",
     },


### PR DESCRIPTION
## Summary

- Change model descriptions to use actual model IDs instead of nicknames
- Add explicit `acceptsReferenceImages: false` to google-imagen schema

## Problem

The AI workflow generator LLM was picking up nickname descriptions ("Nano Banana Pro") from the model parameter descriptions and using them as values instead of the actual enum values (`gemini-3-pro-image-preview`). This caused 400 Bad Request errors with "unexpected model name format".

## Changes

1. **Model descriptions updated** - Changed from `"Nano Banana (fast) or Nano Banana Pro (high quality)"` to use actual model IDs
2. **google-imagen schema** - Added `acceptsReferenceImages: false` to document that Imagen API is text-to-image only (use `gemini-generate` for image-to-image with references)

## Test plan

- [ ] AI workflow generator creates valid model names (no more "Nano Banana Pro")
- [ ] Typecheck passes (verified locally)