### PR TITLE
feat(studio): move Execute and AI Generate to floating canvas buttons

### DIFF
--- a/apps/studio/frontend/src/App.tsx
+++ b/apps/studio/frontend/src/App.tsx
@@ -332,7 +332,7 @@ function App() {
         <WorkflowLibrary />
 
         <div className="floimg-studio h-screen flex flex-col bg-gray-100 dark:bg-zinc-900">
-          <Toolbar onToggleAI={handleToggleAIChat} isAIPanelOpen={isAIPanelOpen} />
+          <Toolbar />
 
           {/* Tab navigation */}
           <div className="floimg-tabs">

--- a/apps/studio/frontend/src/components/Toolbar.tsx
+++ b/apps/studio/frontend/src/components/Toolbar.tsx
@@ -27,10 +27,6 @@ export interface ToolbarProps {
   hideAttribution?: boolean;
   /** Hide the "My Workflows" library toggle button (for wrappers providing custom workflow management) */
   hideWorkflowLibrary?: boolean;
-  /** Callback when AI Generate button is clicked */
-  onToggleAI?: () => void;
-  /** Whether the AI panel is currently open (for visual feedback) */
-  isAIPanelOpen?: boolean;
 }
 
 export function Toolbar({
@@ -40,13 +36,9 @@ export function Toolbar({
   remixInfoSlot,
   hideAttribution = false,
   hideWorkflowLibrary = false,
-  onToggleAI,
-  isAIPanelOpen = false,
 }: ToolbarProps = {}) {
   const execution = useWorkflowStore((s) => s.execution);
   const execute = useWorkflowStore((s) => s.execute);
-  const executeWithValidation = useWorkflowStore((s) => s.executeWithValidation);
-  const cancelExecution = useWorkflowStore((s) => s.cancelExecution);
   const exportToYaml = useWorkflowStore((s) => s.exportToYaml);
   const importFromYaml = useWorkflowStore((s) => s.importFromYaml);
   const nodes = useWorkflowStore((s) => s.nodes);
@@ -106,10 +98,6 @@ export function Toolbar({
     setIsEditingName(false);
   };
 
-  const handleExecute = async () => {
-    await executeWithValidation();
-  };
-
   const handleExecuteAnyway = async () => {
     hideValidationPanel();
     await execute();
@@ -152,24 +140,6 @@ export function Toolbar({
                   d="M4 6h16M4 12h16M4 18h7"
                 />
               </svg>
-            </button>
-          )}
-
-          {/* AI Generate button - placed in left zone for spatial separation from Execute */}
-          {onToggleAI && (
-            <button
-              onClick={onToggleAI}
-              className={`floimg-ai-btn ${isAIPanelOpen ? "floimg-ai-btn--active" : ""}`}
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                />
-              </svg>
-              AI Generate
             </button>
           )}
 
@@ -275,45 +245,6 @@ export function Toolbar({
           >
             Export
           </button>
-
-          {execution.status === "running" ? (
-            <button
-              onClick={cancelExecution}
-              className="floimg-toolbar__btn-primary !bg-red-500 hover:!bg-red-600 flex items-center gap-2"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-              Cancel
-            </button>
-          ) : (
-            <button
-              onClick={handleExecute}
-              disabled={nodes.length === 0}
-              className="floimg-toolbar__btn-primary disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-            >
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              Execute
-            </button>
-          )}
           {afterActionsSlot}
         </div>
       </div>

--- a/apps/studio/frontend/src/editor/studio-theme.css
+++ b/apps/studio/frontend/src/editor/studio-theme.css
@@ -641,28 +641,27 @@
 
 /* ===== NODE TYPE ACCENTS ===== */
 
-/* Generator nodes - blue accent line */
-.floimg-node--generator::before {
+/* Base accent line - ensures full width regardless of content */
+.floimg-node::before {
   content: "";
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
+  width: auto !important; /* Override any computed/inherited width */
   height: 3px;
-  background: linear-gradient(90deg, #3b82f6, #60a5fa);
   border-radius: 12px 12px 0 0;
+  pointer-events: none;
+}
+
+/* Generator nodes - blue accent line */
+.floimg-node--generator::before {
+  background: linear-gradient(90deg, #3b82f6, #60a5fa);
 }
 
 /* Transform nodes - teal accent line */
 .floimg-node--transform::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
   background: linear-gradient(90deg, #0d9488, #14b8a6);
-  border-radius: 12px 12px 0 0;
 }
 
 /* AI transform nodes - indigo accent line */
@@ -672,62 +671,27 @@
 
 /* Save nodes - green accent line */
 .floimg-node--save::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
   background: linear-gradient(90deg, #22c55e, #4ade80);
-  border-radius: 12px 12px 0 0;
 }
 
 /* Input nodes - amber accent line */
 .floimg-node--input::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
   background: linear-gradient(90deg, #f59e0b, #fbbf24);
-  border-radius: 12px 12px 0 0;
 }
 
 /* Vision nodes - cyan accent line */
 .floimg-node--vision::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
   background: linear-gradient(90deg, #06b6d4, #22d3ee);
-  border-radius: 12px 12px 0 0;
 }
 
 /* Text nodes - pink accent line */
 .floimg-node--text::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
   background: linear-gradient(90deg, #ec4899, #f472b6);
-  border-radius: 12px 12px 0 0;
 }
 
 /* Fan-out/Collect/Router - orange accent line */
 .floimg-node--iterative::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
   background: linear-gradient(90deg, #f97316, #fb923c);
-  border-radius: 12px 12px 0 0;
 }
 
 /* ===== EXECUTION STATUS ===== */
@@ -1166,4 +1130,139 @@
 
 .animate-slide-in {
   animation: slide-in 0.2s ease-out forwards;
+}
+
+/* ===== FLOATING CANVAS ACTIONS ===== */
+/* Action buttons positioned on the canvas for spatial proximity to results */
+
+.floimg-canvas-actions {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.floimg-canvas-actions > * {
+  pointer-events: auto;
+}
+
+/* Execute button - primary action, teal gradient */
+.floimg-canvas-actions__execute {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: white;
+  background: linear-gradient(135deg, #0d9488 0%, #14b8a6 100%);
+  border-radius: 10px;
+  box-shadow:
+    0 2px 8px rgba(13, 148, 136, 0.25),
+    0 4px 16px rgba(13, 148, 136, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  transition: all 0.15s ease;
+}
+
+.floimg-canvas-actions__execute:hover:not(:disabled) {
+  box-shadow:
+    0 4px 12px rgba(13, 148, 136, 0.35),
+    0 8px 24px rgba(13, 148, 136, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+}
+
+.floimg-canvas-actions__execute:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.floimg-canvas-actions__execute:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Cancel button - danger state */
+.floimg-canvas-actions__cancel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: white;
+  background: linear-gradient(135deg, #dc2626 0%, #ef4444 100%);
+  border-radius: 10px;
+  box-shadow:
+    0 2px 8px rgba(220, 38, 38, 0.25),
+    0 4px 16px rgba(220, 38, 38, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  transition: all 0.15s ease;
+}
+
+.floimg-canvas-actions__cancel:hover {
+  box-shadow:
+    0 4px 12px rgba(220, 38, 38, 0.35),
+    0 8px 24px rgba(220, 38, 38, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+}
+
+/* AI Generate button - secondary/outline style, positioned near right edge where panel opens */
+.floimg-canvas-actions__ai {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #818cf8;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(129, 140, 248, 0.4);
+  border-radius: 10px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: all 0.15s ease;
+}
+
+.floimg-canvas-actions__ai:hover {
+  background: rgba(129, 140, 248, 0.1);
+  border-color: rgba(129, 140, 248, 0.6);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transform: translateY(-1px);
+}
+
+.floimg-canvas-actions__ai--active {
+  background: rgba(129, 140, 248, 0.15);
+  border-color: rgba(129, 140, 248, 0.8);
+  color: #6366f1;
+}
+
+.floimg-canvas-actions__ai--active:hover {
+  background: rgba(129, 140, 248, 0.2);
+}
+
+@media (prefers-color-scheme: dark) {
+  .floimg-canvas-actions__ai {
+    background: rgba(39, 39, 42, 0.9);
+    color: #a5b4fc;
+    border-color: rgba(165, 180, 252, 0.3);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+
+  .floimg-canvas-actions__ai:hover {
+    background: rgba(129, 140, 248, 0.15);
+    border-color: rgba(165, 180, 252, 0.5);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+
+  .floimg-canvas-actions__ai--active {
+    background: rgba(129, 140, 248, 0.2);
+    border-color: rgba(165, 180, 252, 0.7);
+    color: #c7d2fe;
+  }
 }


### PR DESCRIPTION
## Summary

- Move Execute button from toolbar to floating position on canvas (bottom-right)
- Move AI Generate button from toolbar left to floating position on canvas (right edge, near AI panel)
- Consolidate node header accent line CSS to ensure full-width rendering
- Clean up Toolbar component by removing now-unused props

## Why

The original button placement had spatial mapping issues:
- AI Generate button was in the upper-left (logo zone) but opened a panel on the right (1,131px disconnect)
- Execute button was in the toolbar but triggered actions on the canvas below (57px vertical gap)

Floating buttons directly on the canvas provide better spatial proximity between action triggers and their results.

## Changes

| File | Change |
|------|--------|
| `WorkflowEditor.tsx` | Add floating action buttons container with Execute and AI Generate |
| `Toolbar.tsx` | Remove Execute and AI Generate buttons, remove unused props |
| `App.tsx` | Remove unused `onToggleAI`/`isAIPanelOpen` props from Toolbar |
| `studio-theme.css` | Add `.floimg-canvas-actions` styles, consolidate node `::before` rules |

## Test plan

- [ ] Execute button appears at bottom-right of canvas
- [ ] Execute button shows Cancel state when running
- [ ] AI Generate button appears on right edge of canvas
- [ ] AI Generate button shows active state when panel is open
- [ ] Node header accent lines span full width on all node types
- [ ] Keyboard shortcut (Cmd+/) still toggles AI panel
- [ ] Works in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)